### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/redeployment.yml
+++ b/.github/workflows/redeployment.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: auto-update-cron
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/JiaLe0709/JiaLe0709/security/code-scanning/1](https://github.com/JiaLe0709/JiaLe0709/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to apply only to the specific job). Since the workflow only contains a single job and does not interact with repository contents, issues, or pull requests, the minimal required permission is likely `contents: read`. This will ensure the workflow does not have unnecessary write access to the repository. The change should be made in `.github/workflows/redeployment.yml`, above the `jobs:` key (for root-level permissions) or inside the `build:` job (for job-level permissions).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
